### PR TITLE
add script to verify msig

### DIFF
--- a/verifymsig.sh
+++ b/verifymsig.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Parameter 1 = wasm filename of the code in ./build/artifacts/
+# Parameter 2 = proposer
+# Parameter 3 = proposal name
+
+# Example Usage:
+# ./verifymsig.sh eden_fractal.wasm ironscimitar update
+
+echo ""
+
+echo "Sha256 of code in current build/artifacts/"
+echo "------------------------------------------"
+sha256sum ./build/artifacts/$1
+
+echo ""
+echo "Sha256 of code in msig"
+echo "------------------------------------------"
+cleos -u https://eos.greymass.com multisig review $2 $3 | jq -r '.transaction.actions[0].data.code' | xxd -r -p | sha256sum
+
+echo ""


### PR DESCRIPTION
Helps to verify that the code in a particular msig proposal matches the latest built code in the docker container.

Requirements:
Install jq and xxd inside the container, using:

```
apt-get update && apt-get install -yq jq xxd
```

* jq is a program to parse json
* xxd lets you take a hex string and convert it to binary, needed to convert the hex into binary before applying sha256


Final note:
I added jq and xxd to the default docker image, so all new EOS contracts created with my tool from now on will automatically have jq and xxd in the environment.